### PR TITLE
Fix Emoji size

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -36,6 +36,10 @@ ol {
   a {
     @apply my-2;
   }
+
+  img {
+    max-width: 16px;
+  }
 }
 
 @screen md {

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -38,8 +38,7 @@ ol {
   }
 
   img {
-    max-width: 16px;
-    display: inline;
+    @apply inline w-5;
   }
 }
 

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -39,6 +39,7 @@ ol {
 
   img {
     max-width: 16px;
+    display: inline;
   }
 }
 


### PR DESCRIPTION
# Description
I found an issue with emojis, because those are rendered as `<img>`
The fix was simple, 


# Screenshots
![image](https://user-images.githubusercontent.com/662916/66766466-7370c000-eeae-11e9-9759-b94a58117fb0.png)


# Issues
Closes #151 
Related to #150  